### PR TITLE
Add a manifest header

### DIFF
--- a/manifest.header
+++ b/manifest.header
@@ -1,0 +1,10 @@
+# Header of manifest
+# Merge manifest files from each branch afterwards 
+# Maintainers, repo and constraints are common headers for every release
+Maintainers: Flavio Castelli <fcastelli@suse.com> (@flavio),
+             Aleksa Sarai <asarai@suse.com> (@cyphar),
+             Jordi Massaguer Pla <jmassaguerpla@suse.com> (@jordimassaguerpla),
+             David Cassany Viladomat <dcassany@suse.com> (@davidcassany)
+GitRepo: https://github.com/openSUSE/docker-containers-build.git
+Constraints: !aufs
+


### PR DESCRIPTION
So that we can build the manifest file with this header and then
appending the manifests from each branch.

This needs the manifests files to be adapted

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>